### PR TITLE
leave room function extracted

### DIFF
--- a/src/utils/leaveHandler.ts
+++ b/src/utils/leaveHandler.ts
@@ -1,0 +1,26 @@
+// import { NavigateFunction } from "react-router-dom";
+import { Socket } from "socket.io-client";
+import { NavigateFunction } from "react-router-dom";
+
+interface HandleLeaveProps{
+    peerConnection: React.MutableRefObject<RTCPeerConnection | null>;
+    socket: Socket;
+    localVideoRef: React.RefObject<HTMLVideoElement>,
+    navigate: NavigateFunction
+}
+
+export const handleLeaveRoom = ({peerConnection, socket, localVideoRef, navigate}:HandleLeaveProps ) => {
+    if (peerConnection?.current) {
+      socket.emit("leaveRoom");
+      peerConnection.current.close();
+      peerConnection.current = null;
+    }
+    // Clean up video tracks
+    if (localVideoRef.current?.srcObject instanceof MediaStream) {
+      localVideoRef.current.srcObject
+        .getTracks()
+        .forEach((track) => track.stop());
+    }
+    navigate("/");
+    window.location.reload();
+  };


### PR DESCRIPTION
function to leave chat extracted and used as an import.

The function
- takes peer connection state, socket, local video state, navigation

- Checks if there's a peer connection (ongoing call)

- Sends a message to the server that the room is being left

- Closes the Connection and resets the peer connection state

- It then reset's all media access, heads back to the lobby then reloads the lobby

- The purpose of the reload is to force the browser to sever the connection to media resources so users can start a new call